### PR TITLE
[FIX] l10n_be_bpost_address_validation: Simplify implementation

### DIFF
--- a/l10n_be_bpost_address_validation/tests/test_bpost_address_validation_wizard.py
+++ b/l10n_be_bpost_address_validation/tests/test_bpost_address_validation_wizard.py
@@ -96,7 +96,6 @@ class TestBpostAddressValidationWizard(TransactionCase):
         cls.wizard = cls.env["bpost.address.validation.wizard"].create(
             {"partner_id": cls.partner.id}
         )
-        cls.wizard._compute_response_address()
 
     @classmethod
     def tearDownClass(cls):
@@ -107,41 +106,31 @@ class TestBpostAddressValidationWizard(TransactionCase):
 
     def test_apply_changes(self):
         self.wizard.apply_changes()
-
         self.assertEqual("QUAI BANNING 6", self.partner.street)
         self.assertEqual("LIÈGE", self.partner.city)
         self.assertEqual("4000", self.partner.zip)
 
     def test_suggest_changes(self):
         self.assertEqual("QUAI BANNING 6 4000, LIÈGE", self.wizard.suggest_changes)
-        self.assertFalse(self.wizard.bad_address)
         self.assertFalse(self.wizard.is_valid)
 
     def test_invalid_address(self):
         self.partner.street = "Quai Banning"
-        self.wizard._compute_response_address()
-        self.assertTrue(self.wizard.bad_address)
         self.assertFalse(self.wizard.is_valid)
 
     def test_valid_address(self):
         self.partner.street = "Quai Banning 6"
-        self.wizard._compute_response_address()
         self.assertTrue(self.wizard.is_valid)
-        self.assertFalse(self.wizard.bad_address)
 
     def test_partner_from_another_country(self):
         wizard = self.env["bpost.address.validation.wizard"].create(
             {"partner_id": self.partner_lu.id}
         )
-        wizard._compute_response_address()
         self.assertTrue(wizard.is_valid)
-        self.assertFalse(wizard.bad_address)
 
     def test_invalid_address_and_apply_changes(self):
         self.partner.street = "Quai Banning"
-        self.wizard._compute_response_address()
         self.wizard.apply_changes()
-        self.assertTrue(self.wizard.bad_address)
         self.assertFalse(self.wizard.is_valid)
         self.assertEqual(
             "The given address is not complete or the address cannot be found.",
@@ -153,6 +142,4 @@ class TestBpostAddressValidationWizard(TransactionCase):
 
     def test_address_not_found(self):
         self.partner.street = "benneng"
-        self.wizard._compute_response_address()
-        self.assertTrue(self.wizard.bad_address)
         self.assertFalse(self.wizard.is_valid)

--- a/l10n_be_bpost_address_validation/wizards/bpost_address_validation.py
+++ b/l10n_be_bpost_address_validation/wizards/bpost_address_validation.py
@@ -10,68 +10,62 @@ from ..models.bpost_address import BpostAddress
 
 class BpostAddressValidationWizard(models.TransientModel):
     _name = "bpost.address.validation.wizard"
+    _description = "Address Validator Using Bpost API"
 
     partner_id = fields.Many2one("res.partner", readonly=True)
-    is_valid = fields.Boolean(compute="_compute_response_address")
-    bad_address = fields.Boolean()
-    warning_message = fields.Char(readonly=True)
-    suggest_changes = fields.Char(readonly=True)
-    bpost_address = fields.Json()
+    is_valid = fields.Boolean(compute="_compute_address_validity")
+    warning_message = fields.Char(compute="_compute_address_validity")
+    suggest_changes = fields.Char(compute="_compute_address_validity")
+    bpost_address = fields.Json(compute="_compute_address_validity")
 
-    @api.depends("partner_id")
-    def _compute_response_address(self):
+    @api.depends("partner_id", "partner_id.street", "partner_id.city", "partner_id.zip")
+    def _compute_address_validity(self):
         for rec in self:
             partner = rec.partner_id
+            rec.is_valid = True
+            rec.warning_message = ""
+            rec.suggest_changes = ""
+            rec.bpost_address = {}
             if partner.country_id.code == "BE":
                 # This is the JSON that should be sent as input to the API.
-                response = self.send_request(partner)
+                response = self._send_request(partner)
                 if response.ok:
                     json = response.json()
                     # Transform the result into a BpostAddress object.
                     rec.bpost_address = BpostAddress(json).toJson()
                     if "error" in rec.bpost_address:
+                        rec.is_valid = False
                         if (
                             "street_name" in rec.bpost_address
                             and "postal_code" in rec.bpost_address
                             and "municipality_name" in rec.bpost_address
                             and "street_number" in rec.bpost_address
                         ):
-                            self.invalid_address_and_suggest_changes(rec)
+                            rec.warning_message = _(
+                                "An error has been detected in the given address. "
+                                + "Would you like to keep the suggest change ?"
+                            )
+                            rec.suggest_changes = self._format_suggest_changes(
+                                rec)
                         else:
-                            self.invalid_address(rec)
-                    else:
-                        rec.is_valid = True
+                            rec.warning_message = _(
+                                "The given address is not complete or the address cannot be found."
+                            )
                 else:
                     raise UserError(
                         _("An error occurred when fetching data from bpost API.")
                     )
-            else:
-                rec.is_valid = True
 
-    def invalid_address(self, rec):
-        rec.warning_message = _(
-            "The given address is not complete or the address cannot be found."
-        )
-        rec.bad_address = True
-        rec.is_valid = False
-
-    def invalid_address_and_suggest_changes(self, rec):
-        rec.warning_message = _(
-            "An error has been detected in the given address. "
-            + "Would you like to keep the suggest change ?"
-        )
-        changes = "{} {} {}, {}".format(
+    def _format_suggest_changes(self, rec):
+        return "{} {} {}, {}".format(
             rec.bpost_address["street_name"],
             rec.bpost_address["street_number"],
             rec.bpost_address["postal_code"],
             rec.bpost_address["municipality_name"],
         )
 
-        rec.suggest_changes = changes
-        rec.bad_address = False
-        rec.is_valid = False
 
-    def send_request(self, partner):
+    def _send_request(self, partner):
         playload = {
             "ValidateAddressesRequest": {
                 "AddressToValidateList": {
@@ -130,4 +124,3 @@ class BpostAddressValidationWizard(models.TransientModel):
                 partner.city = rec.bpost_address["municipality_name"]
                 partner.zip = rec.bpost_address["postal_code"]
                 rec.suggest_changes = ""
-                rec.bad_address = False

--- a/l10n_be_bpost_address_validation/wizards/bpost_address_validation.xml
+++ b/l10n_be_bpost_address_validation/wizards/bpost_address_validation.xml
@@ -8,7 +8,6 @@
                 <field name="bpost_address" invisible="1" />
                 <field name="partner_id" invisible="1" />
                 <field name="is_valid" invisible="1" />
-                <field name="bad_address" invisible="1" />
                 <div
                     class="text-danger mb-3"
                     attrs="{'invisible': [('is_valid','=', True)]}"
@@ -24,9 +23,7 @@
                 >
                     <span>Success ! The address given is valid.</span>
                 </div>
-                <footer
-                    attrs="{'invisible': ['|',('is_valid', '=', True),('bad_address', '=', True)]}"
-                >
+                <footer attrs="{'invisible': [('suggest_changes', '=', '')]}">
                     <button
                         type="object"
                         name="apply_changes"


### PR DESCRIPTION
Since all the fields into the wizard are computed from the call to the bpost api they are now declared as computed.